### PR TITLE
Expand environment variables in .ini files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma\: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == "__main__"\:
+    def includeme\(config\)\:
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,19 +8,11 @@
 *.egg
 *.egg-info
 dist
-build
-include
-lib
 man
 local
 eggs
-parts
-bin
 var
 sdist
-develop-eggs
-.installed.cfg
-.eggs/
 pip-selfcheck.json
 
 # Installer logs
@@ -33,10 +25,7 @@ pip-log.txt
 #Translations
 *.mo
 
-#Mr Developer
-.mr.developer.cfg
-
-env
-env27
 coverage.xml
-nosetests.xml
+.pytest_cache/
+htmlcov/
+.venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,17 @@
-sudo: false
+dist: xenial
+sudo: required
 language: python
 python:
-  - 2.7
-  - 3.5
+  - 3.7
+
+env:
+  global:
+  - PIPENV_IGNORE_VIRTUALENVS=1
+
+install:
+ - pipenv install --dev --deploy
 
 script:
- - python -Wd setup.py test -q
-
-notifications:
-  slack:
-    secure: |-
-      WqT8DOMtIV12SUSlPydfIzpWOcZJMW15kBWGtEL8dWQ+vtCO3H1A+hKfml9QSN63B/
-      PLILK3KlL8sj+Z5KT4vTnIQ4eACij9YYBuJniYhXzg0w3gzI5pqSDUcSn9wHevfOyk
-      /xKJ3A6AZV2Nvl6xT4pTSHdQS8St/h58MnC49x4NTXeRM3NAeJryeWCM5lIeIBnycR
-      rHRKZHnBbjSTs9sRLsqaGugKGJzGWtOibCTchbh18t9/sNEdqMhz/QzAgZ4VJfv9Vb
-      1CzKiaiAfCZcmagS1lxbEXTytUju93xJ8QQjFhFy/tyTJQ95OcmCm8Lb0P1xczlxwR
-      ufGOynTPmKxWCkdrOrMYatTFT21Qd4O+Gumh7PngJqYOeEzXOSXSzPZHVAbtv73iMP
-      8KIj5OmyGjV1uvcN+x2OaQOXVv/m8mb+SZW78DM3S1IAR6+LrAQ6mBx2FJudCUfEol
-      G8g5VoX2nvD3E66VTFT9ZYqZisOPF+aojufeBT0XtGVftCnpfpY6qKLwdlFxXeeHio
-      NKB+4q1LGDR1f3pGzVVJ9588O/gUwiLX/KwkouTGQ91bivFj/Cy8IgJ8oto3W7SePz
-      pz4iiiLRXWLWDBfND2JWpiJLosGYrr1cfbbp1oB2pxARGgg3RpDDo++U9TgrCyqpjs
-      uR7wtEy2VdbjatPTkNM9Fk0="
+ - pipenv run coverage run --branch --source pyramid_heroku -m pytest pyramid_heroku
+ - pipenv run coverage html
+ - pipenv run coverage report --fail-under=95

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,24 @@
 Changes
 =======
 
+0.2
+---
+
+* Expand all environment variables in the settings dictionary. This allows you
+  to have, for example `${DATABASE_URL}` to get db connection string from
+  environment into your `production.ini` file.
+  [zupo]
+
+* Use pipenv for setting up development.
+  [zupo]
+
+* Add basic type hinting.
+  [zupo]
+
+* Drop support for Python versions older than 3.7.
+  [zupo]
+
+
 0.1.5
 -----
 
@@ -34,6 +52,7 @@ Changes
 
 * Fix tween paths.
   [zupo]
+
 
 
 0.1

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,18 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pyramid-heroku = {editable = true, path = "."}
+
+[dev-packages]
+mock = "*"
+responses = "*"
+"zope.testing" = "*"
+coverage = "*"
+pytest = "*"
+docutils = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,327 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "1ff115d8a5af3249db00f864dd09bda74d32e50707ef59fa378625b64cd12830"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+            ],
+            "version": "==2018.4.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "hupper": {
+            "hashes": [
+                "sha256:20387760e4d32bd4813c2cabc8e51d92b2c22c546102a0af182c33c152cd7ede",
+                "sha256:6b8133e9c5cc0a8ec422a29ef3b38aea2c49a809a0af73f419a78a7015b32615"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==1.3"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "pastedeploy": {
+            "hashes": [
+                "sha256:39973e73f391335fac8bc8a8a95f7d34a9f42e2775600ce2dc518d93b37ef943",
+                "sha256:d5858f89a255e6294e63ed46b73613c56e3b9a2d82a42f1df4d06c8421a9e3cb"
+            ],
+            "version": "==1.5.2"
+        },
+        "plaster": {
+            "hashes": [
+                "sha256:215c921a438b5349931fd7df9a5a11a3572947f20f4bc6dd622ac08f1c3ba249",
+                "sha256:8351c7c7efdf33084c1de88dd0f422cbe7342534537b553c49b857b12d98c8c3"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==1.0"
+        },
+        "plaster-pastedeploy": {
+            "hashes": [
+                "sha256:71e29b0ab90df8343bca5f0debe4706f0f8147308a78922c8c26e8252809bce4",
+                "sha256:c231130cb86ae414084008fe1d1797db7e61dc5eaafb5e755de21387c27c6fae"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*'",
+            "version": "==0.6"
+        },
+        "pyramid": {
+            "hashes": [
+                "sha256:600f12e0d11211a55c2da970120af33214f77607ed45caba6af6c891afeaa771",
+                "sha256:cf89a48cb899291639686bf3d4a883b39e496151fa4871fb83cc1a3200d5b925"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==1.9.2"
+        },
+        "pyramid-heroku": {
+            "editable": true,
+            "path": "."
+        },
+        "repoze.lru": {
+            "hashes": [
+                "sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77",
+                "sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea"
+            ],
+            "version": "==0.7"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+            ],
+            "version": "==2.19.1"
+        },
+        "translationstring": {
+            "hashes": [
+                "sha256:4ee44cfa58c52ade8910ea0ebc3d2d84bdcad9fa0422405b1801ec9b9a65b72d",
+                "sha256:e26c7bf383413234ed442e0980a2ebe192b95e3745288a8fd2805156d27515b4"
+            ],
+            "version": "==1.3"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+            ],
+            "markers": "python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version < '4' and python_version != '3.2.*' and python_version >= '2.6'",
+            "version": "==1.23"
+        },
+        "venusian": {
+            "hashes": [
+                "sha256:757162c5f907e18571b6ab41b7673e5bf18cc8715abf8164292eaef4f1610668",
+                "sha256:9902e492c71a89a241a18b2f9950bea7e41d025cc8f3af1ea8d8201346f8577d"
+            ],
+            "version": "==1.1.0"
+        },
+        "webob": {
+            "hashes": [
+                "sha256:1fe722f2ab857685fc96edec567dc40b1875b21219b3b348e58cd8c4d5ea7df3",
+                "sha256:263690003a3e092ca1ec4df787f93feb0004e39d7bac9cba2c19a552c765894b"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.0.*'",
+            "version": "==1.8.2"
+        },
+        "zope.deprecation": {
+            "hashes": [
+                "sha256:7d52e134bbaaa0d72e1e2bc90f0587f1adc116c4bdf15912afaf2f1e8856b224",
+                "sha256:c83cfef3085d10dcb07de5a59a2d95713865befa46e0e88784c5648610fba789"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==4.3.0"
+        },
+        "zope.interface": {
+            "hashes": [
+                "sha256:21506674d30c009271fe68a242d330c83b1b9d76d62d03d87e1e9528c61beea6",
+                "sha256:3d184aff0756c44fff7de69eb4cd5b5311b6f452d4de28cb08343b3f21993763",
+                "sha256:467d364b24cb398f76ad5e90398d71b9325eb4232be9e8a50d6a3b3c7a1c8789",
+                "sha256:57c38470d9f57e37afb460c399eb254e7193ac7fb8042bd09bdc001981a9c74c",
+                "sha256:9ada83f4384bbb12dedc152bcdd46a3ac9f5f7720d43ac3ce3e8e8b91d733c10",
+                "sha256:a1daf9c5120f3cc6f2b5fef8e1d2a3fb7bbbb20ed4bfdc25bc8364bc62dcf54b",
+                "sha256:e6b77ae84f2b8502d99a7855fa33334a1eb6159de45626905cb3e454c023f339",
+                "sha256:e881ef610ff48aece2f4ee2af03d2db1a146dc7c705561bd6089b2356f61641f",
+                "sha256:f41037260deaacb875db250021fe883bf536bf6414a4fd25b25059b02e31b120"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==4.5.0"
+        }
+    },
+    "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+            ],
+            "version": "==1.1.5"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+            ],
+            "version": "==18.1.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+            ],
+            "version": "==2018.4.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "cookies": {
+            "hashes": [
+                "sha256:15bee753002dff684987b8df8c235288eb8d45f8191ae056254812dfd42c81d3",
+                "sha256:d6b698788cae4cfa4e62ef8643a9ca332b79bd96cb314294b864ae8d7eb3ee8e"
+            ],
+            "version": "==2.2.1"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
+                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
+                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
+                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
+                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
+                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
+                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
+                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
+                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
+                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
+                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
+                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
+                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
+                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
+                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
+                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
+                "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
+                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
+                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
+                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
+                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
+                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
+                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
+                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
+                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
+                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
+            ],
+            "index": "pypi",
+            "version": "==4.5.1"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "index": "pypi",
+            "version": "==0.14"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1",
+                "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
+                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
+                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+            ],
+            "version": "==4.2.0"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:1b8be50d938c9bb75d0eaf7eda111eec1bf6dc88a62a6412e33bf077457e0f45",
+                "sha256:b486975c0cafb6beeb50ca0e17ba047647f229087bd74e37f4a7e2cac17d2caa"
+            ],
+            "version": "==4.2.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==0.6.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==1.5.4"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752",
+                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d"
+            ],
+            "index": "pypi",
+            "version": "==3.6.3"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+            ],
+            "version": "==2.19.1"
+        },
+        "responses": {
+            "hashes": [
+                "sha256:c6082710f4abfb60793899ca5f21e7ceb25aabf321560cc0726f8b59006811c9",
+                "sha256:f23a29dca18b815d9d64a516b4a0abb1fbdccff6141d988ad8100facb81cf7b3"
+            ],
+            "index": "pypi",
+            "version": "==0.9.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+            ],
+            "markers": "python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version < '4' and python_version != '3.2.*' and python_version >= '2.6'",
+            "version": "==1.23"
+        },
+        "zope.testing": {
+            "hashes": [
+                "sha256:6f60f9847b33f3b63ad42cee67019f2013eb37384c49f7f77d624e2821293846",
+                "sha256:a529fb037148b41df264596a449974ef9d40e4006e73702a5cfdb4f215c0e1d8"
+            ],
+            "index": "pypi",
+            "version": "==4.6.2"
+        }
+    }
+}

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,6 @@
 pyramid_heroku
-================
+==============
 
-------------
 Introduction
 ------------
 
@@ -15,7 +14,7 @@ It provides the following:
 * ``migrate.py`` script for automatically running alembic migrations on
   deploy.
 
-------------
+
 Installation
 ------------
 
@@ -27,14 +26,14 @@ or
 
 ``easy_install pyramid_heroku``
 
--------------
+
 Compatibility
 -------------
 
 pyramid_heroku runs with pyramid>=1.7 and python>=2.7 and python>=3.5.
 Other versions might also work.
 
--------------
+
 Documentation
 -------------
 
@@ -77,11 +76,12 @@ Releasing
 
 #. Update CHANGES.rst.
 #. Update setup.py version.
-#. Run ``bin/longtest``.
-#. Run ``python setup.py sdist upload``.
+#. Run ``pipenv run python setup.py check -rs``.
+#. Run ``pipenv run python setup.py sdist upload``.
+
 
 We're hiring!
-=============
+-------------
 
 At Niteo we regularly contribute back to the Open Source community. If you do too, we'd like to invite you to `join our team
 <https://niteo.co/careers/>`_!

--- a/pyramid_heroku/__init__.py
+++ b/pyramid_heroku/__init__.py
@@ -1,1 +1,45 @@
-# -*- coding: utf-8 -*-
+"""Various utilities."""
+
+from ast import literal_eval
+
+import os
+import sys
+import typing as t
+
+
+def safe_eval(text: str) -> str:
+    """Safely evaluate `text` argument.
+
+    `text` can be evaluated to string, number,
+    tuple, list, dict, boolean, and None.
+    Code `text[0].upper + text[1:]` is for lower case
+    'false' or 'true' strings, it should not break anything.
+    """
+    if not isinstance(text, str):
+        raise ValueError(f"Expected a string, got {type(text)} instead.")
+
+    try:
+        if len(text) == 0:
+            return None
+        else:
+            return literal_eval(text[0].upper() + text[1:])
+    except (ValueError, SyntaxError):
+        return text
+
+
+def expandvars_dict(settings: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
+    """Expand all environment variables in a settings dictionary.
+
+    Env vars are expanded twice, so you can have (1-level) nesting. Example:
+
+    $ export FOO='foo'
+    $ export BAR='${FOO}bar'
+    $ bin/py
+    >>> from pyramid_heroku import expandvars_dict
+    >>> expandvars_dict({'my_var': '${BAR}'})
+    {'my_var': 'foobar'}
+    """
+    return {
+        key: safe_eval(os.path.expandvars(os.path.expandvars(value)))
+        for (key, value) in settings.items()
+    }

--- a/pyramid_heroku/client_addr.py
+++ b/pyramid_heroku/client_addr.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
+"""Set client_add IP that we can trust."""
 
 def includeme(config):
     config.add_tween('pyramid_heroku.client_addr.ClientAddr')

--- a/pyramid_heroku/herokuapp_access.py
+++ b/pyramid_heroku/herokuapp_access.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
+"""Prevent .herokuapp.com access to non-whitelisted IPs"""
 
-from __future__ import unicode_literals
 from pyramid.response import Response
 
 import logging
@@ -47,8 +46,8 @@ class HerokuappAccess(object):
             else:
                 logger = logging.getLogger(__name__)
                 logger.info(
-                    'Denied Herokuapp access for Host {} and IP {}'.format(
-                        request.headers['Host'], request.client_addr))
+                    f'Denied Herokuapp access for Host {request.headers["Host"]}'
+                    f' and IP {request.client_addr}')
 
             resp = Response(
                 'Unauthorized.',

--- a/pyramid_heroku/tests/test_client_addr.py
+++ b/pyramid_heroku/tests/test_client_addr.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 """Tests for ClientAddr tween."""
 
-from __future__ import unicode_literals
 from pyramid import request
 from pyramid import testing
 

--- a/pyramid_heroku/tests/test_herokuapp_access.py
+++ b/pyramid_heroku/tests/test_herokuapp_access.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 """Tests for HerokuappAccess tween."""
 
-from __future__ import unicode_literals
 from pyramid import testing
 from zope.testing.loggingsupport import InstalledHandler
 

--- a/pyramid_heroku/tests/test_migrate.py
+++ b/pyramid_heroku/tests/test_migrate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for Heroku migrate script."""
 
 from mock import call

--- a/pyramid_heroku/tests/test_utils.py
+++ b/pyramid_heroku/tests/test_utils.py
@@ -1,0 +1,72 @@
+"""Tests for utils."""
+
+import pytest
+
+
+def test_safe_eval():
+    """Test that dangerous values are safely eval-ed."""
+    from pyramid_heroku import safe_eval
+
+    assert safe_eval("False") is False
+    assert safe_eval("True") is True
+    assert safe_eval("false") is False
+    assert safe_eval("true") is True
+    assert safe_eval("1337") == 1337
+    assert safe_eval("1337.1337") == 1337.1337
+    assert safe_eval("asdfghjkl") == "asdfghjkl"
+    assert safe_eval("asdfg hjkl") == "asdfg hjkl"
+    assert safe_eval("'asdfg hjkl'") == "asdfg hjkl"
+    assert safe_eval("u'true'") == "true"
+    assert (
+        safe_eval("raise Exception('Chrashed yet?')")
+        == "raise Exception('Chrashed yet?')"
+    )
+
+    assert safe_eval("exit") == "exit"
+    assert safe_eval("exit(12)") == "exit(12)"
+    assert safe_eval("None") is None
+    assert safe_eval("('test', 'tIsT')") == ("test", "tIsT")
+    assert safe_eval("(('fOo', 'BaRrAr'), ('asd', 'AsD'))") == (
+        ("fOo", "BaRrAr"),
+        ("asd", "AsD"),
+    )
+
+    assert safe_eval("") is None
+    assert safe_eval("[]") == []
+    with pytest.raises(ValueError):
+        assert safe_eval(None) == []
+        assert safe_eval([1, 2, 3]) == []
+
+
+def test_expandvars_dict():
+    """Test that env vars are added to settings dict."""
+    from pyramid_heroku import expandvars_dict
+    import os
+
+    os.environ["FOO"] = "foo"
+    os.environ["BAR"] = "${FOO}bar"
+    settings = {
+        "test_boolean": "true",
+        "test_integer": "1337",
+        "test_string": "'asdfg hjkl'",
+        "test_none": "None",
+        "test_set": "('test', 'tIsT')",
+        "test_multi_set": "(('fOo', 'BaRrAr'), ('asd', 'AsD'))",
+        "test_empty": "",
+        "test_env": "${FOO}",
+        "test_env_nested": "${BAR}",
+    }
+
+    expanded_settings = {
+        "test_boolean": True,
+        "test_integer": 1337,
+        "test_string": "asdfg hjkl",
+        "test_none": None,
+        "test_set": ("test", "tIsT"),
+        "test_multi_set": (("fOo", "BaRrAr"), ("asd", "AsD")),
+        "test_empty": None,
+        "test_env": "foo",
+        "test_env_nested": "foobar",
+    }
+
+    assert expanded_settings == expandvars_dict(settings)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[easy_install]
-zip_ok = false
-
-[nosetests]
-match=^test
-where=pyramid_heroku
-nocapture=1
-cover-package=pyramid_heroku
-cover-erase=1

--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,12 @@ changes = open(os.path.join(here, 'CHANGES.rst')).read()
 requires = [
     'pyramid>=1.7',
     'requests',
-    'future',
 ]
 
-tests_require = [
-    'mock',
-    'responses',
-    'zope.testing',
-]
 
 setup(
     name='pyramid_heroku',
-    version='0.1.5',
+    version='0.2',
     description='A bunch of helpers for successfully running Pyramid on Heroku.',
     long_description=readme + '\n' + changes,
     classifiers=[
@@ -31,17 +25,18 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Framework :: Pylons",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: WSGI",
         "Topic :: Software Development :: Libraries :: Python Modules",
         ],
     packages=['pyramid_heroku'],
     install_requires=requires,
-    author='NiteoWeb Ltd.',
-    author_email='info@niteoweb.com',
+    author='Niteo',
+    author_email='info@niteo.co',
     license='BSD',
     url='https://github.com/niteoweb/pyramid_heroku',
     keywords='pyramid heroku pylons web',
-    tests_require=requires + tests_require,
     test_suite='pyramid_heroku',
 )


### PR DESCRIPTION
Also:
* Use pipenv for setting up development.
* Add basic type hinting.
* Drop support for Python versions older than 3.7.