### PR TITLE
Update how alembic should be called

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Usage example for automatic alembic migration script::
     set -e
 
     echo "Running migrations"
-    python -m pyramid_heroku.migrate my_app etc/production.ini app:main
+    python -m pyramid_heroku.migrate my_app etc/production.ini
 
     echo "DONE!"
 


### PR DESCRIPTION
As of latest version of [pyramid_deferred_sqla](https://github.com/niteoweb/pyramid_deferred_sqla/commit/b963702cab3934116fb00b6ef186959bc1627026)
alembic calls have changed a bit. This commit updates how migrate.py
calls alembic.