### PR TITLE
Add manual trigger for poetry update workflow

### DIFF
--- a/.github/workflows/poetry-update.yml
+++ b/.github/workflows/poetry-update.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # On the second of every month
     - cron: '0 0 2 * *'
+  workflow_dispatch:
 
 jobs:
   update:
@@ -11,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: abatilo/actions-poetry@v1.5.0
+        uses: abatilo/actions-poetry@v2.0.0
         with:
           python_version: 3.6.0
           poetry_version: 1.0.5


### PR DESCRIPTION
With this, we can manually trigger the workflow from the "Actions" tab.