### PR TITLE
Add more control for setting Heroku maintenance mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,14 @@ Changes
    This helps when we want to enable/disable the maintenance mode manually or externally.
    [sayanarijit]
 
+ * Add options to manually enable or disable Heroku maintenance mode.
+   Use `pyramid_heroku.maintenance` script to manage the maintenance state.
+   [sayanarijit]
+
+ * Heroku API client related code has been moved from `pyramid_heroku.migrate` to
+   `pyramid_heroku.heroku`, while the `shell` function is now in `pyramid_heroku`.
+   [sayanarijit]
+
 
 0.7.0
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changes
 =======
 
+0.8.0
+-----
+
+ * Do not touch Heroku maintenance mode during migration if it's already enabled.
+   This helps when we want to enable/disable the maintenance mode manually or externally.
+   [sayanarijit]
+
+
 0.7.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ It provides the following:
   ``<app>.herokuapp.com`` domain for any non-whitelisted IPs.
 * ``migrate.py`` script for automatically running alembic migrations on
   deploy.
+* ``maintenance.py`` script for controlling Heroku maintenance mode.
 
 
 Installation
@@ -46,9 +47,10 @@ Usage example for tweens::
         config.include('pyramid_heroku.herokuapp_access')
         return config.make_wsgi_app()
 
-The `pyramid_heroku.herokuapp_access` tween depends on
-`pyramid_heroku.client_addr` tween and it requires you to list whitelisted IPs
-in the `pyramid_heroku.herokuapp_whitelist` setting.
+The ``pyramid_heroku.herokuapp_access`` tween depends on
+``pyramid_heroku.client_addr`` tween and it requires you to list whitelisted IPs
+in the ``pyramid_heroku.herokuapp_whitelist`` setting.
+
 
 Usage example for automatic alembic migration script::
 
@@ -65,11 +67,25 @@ Usage example for automatic alembic migration script::
 For migration script to work, you need to set the ``MIGRATE_API_SECRET_HEROKU``
 env var in Heroku. This allows the migration script to use the Heroku API.
 
-See tests for more examples.
+
+Before running DB migration, the script will enable `Heroku maintenance mode <https://devcenter.heroku.com/articles/maintenance-mode>`_
+if the app is not already in maintenance mode. After the migration, maintenance mode will
+be disabled only if it was enabled by the migration script.
+
+Maintenance mode can also be enabled/disabled using the ``pyramid_heroku.maintenance`` script.
+
+Usage example for enabling the Heroku maintenance mode::
+
+    python -m pyramid_heroku.maintenance on my_app etc/production.ini
+
 
 If you use structlog, add the following configuration setting to your INI file to enable structlog-like logging::
 
     pyramid_heroku.structlog = true
+
+
+See tests for more examples.
+
 
 
 Releasing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyramid_heroku"
-version = "0.7.0"
+version = "0.8.0"
 description = "A bunch of helpers for successfully running Pyramid on Heroku."
 readme = "README.rst"
 include = [ "CHANGES.rst", "COPYING.txt" ]

--- a/pyramid_heroku/__init__.py
+++ b/pyramid_heroku/__init__.py
@@ -3,7 +3,25 @@
 from ast import literal_eval
 from expandvars import expandvars
 
+import shlex
+import subprocess
+import sys
 import typing as t
+
+
+def shell(cmd: str) -> str:
+    """
+    Run shell command.
+
+    :param cmd: shell command to run
+    :return: stdout of command
+    """
+
+    p = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    print(p.stdout.decode())
+    print(p.stderr.decode(), file=sys.stderr)
+    p.check_returncode()
+    return p.stdout.decode()
 
 
 def safe_eval(text: str) -> t.Optional[str]:

--- a/pyramid_heroku/__init__.py
+++ b/pyramid_heroku/__init__.py
@@ -3,7 +3,6 @@
 from ast import literal_eval
 from expandvars import expandvars
 
-import sys
 import typing as t
 
 

--- a/pyramid_heroku/heroku.py
+++ b/pyramid_heroku/heroku.py
@@ -1,0 +1,99 @@
+"""Heroku API client."""
+
+from requests import Response
+from requests import Session
+from typing import Optional
+
+import os
+
+
+class Heroku(object):
+
+    api_endpoint = "https://api.heroku.com"
+
+    def __init__(self, app_name: str, ini_file: str) -> None:
+        """
+        :param app_name: Name of Heroku app or id.
+        :param ini_file: development.ini or production.ini filename.
+        """
+        self._formation = None
+        self.app_name = app_name
+        self.ini_file = ini_file
+
+        headers = {
+            "Authorization": f"Bearer {self.auth_key}",
+            "Accept": "application/vnd.heroku+json; version=3",
+            "Content-Type": "application/json",
+        }
+        self.session = Session()
+        self.session.headers.update(headers)
+
+    @property
+    def auth_key(self) -> Optional[str]:
+        """Heroku API secret.
+
+        https://devcenter.heroku.com/articles/platform-api-quickstart#authentication.
+        """
+        return os.environ.get("MIGRATE_API_SECRET_HEROKU")
+
+    def scale_down(self):
+        """Scale all app workers to 0."""
+        updates = [dict(type=t, quantity=0) for t in self.formation.keys()]
+        res = self.session.patch(
+            f"{self.api_endpoint}/apps/{self.app_name}/formation",
+            json=dict(updates=updates),
+        )
+        self.parse_response(res)
+        print("Scaled down to:")
+        for x in res.json():
+            print(f'{x["type"]}={x["quantity"]}')
+
+    def scale_up(self):
+        """Scale app back to initial state."""
+        updates = [dict(type=t, quantity=s) for t, s in self.formation.items()]
+        res = self.session.patch(
+            f"{self.api_endpoint}/apps/{self.app_name}/formation",
+            json=dict(updates=updates),
+        )
+        self.parse_response(res)
+        print("Scaled up to:")
+        for x in res.json():
+            print(f'{x["type"]}={x["quantity"]}')
+
+    @property
+    def formation(self):
+        """Get current app status and configuration.
+
+        :return: Heroku app status as dict.
+        """
+        if not self._formation:
+            res = self.session.get(
+                f"{self.api_endpoint}/apps/{self.app_name}/formation"
+            )
+            self.parse_response(res)
+            self._formation = {x["type"]: x["quantity"] for x in res.json()}
+        return self._formation
+
+    def get_maintenance(self) -> bool:
+        res = self.session.get(f"{self.api_endpoint}/apps/{self.app_name}")
+        self.parse_response(res)
+        return res.json()["maintenance"]
+
+    def set_maintenance(self, state: bool) -> None:
+        res = self.session.patch(
+            f"{self.api_endpoint}/apps/{self.app_name}", json=dict(maintenance=state)
+        )
+        if self.parse_response(res):
+            print("Maintenance {}".format("enabled" if state else "disabled"))
+
+    def parse_response(self, res: Response) -> Optional[bool]:
+        """
+        Parses Heroku API response.
+
+        :param res: requests object
+        :return: true if request succeeded
+        """
+        if res.status_code != 200:
+            print(res.json())
+        res.raise_for_status()
+        return True

--- a/pyramid_heroku/maintenance.py
+++ b/pyramid_heroku/maintenance.py
@@ -1,0 +1,44 @@
+"""Enable or disable Heroku app maintenance mode."""
+
+from enum import Enum
+from pyramid_heroku.heroku import Heroku
+
+import argparse
+
+
+class Mode(Enum):
+    """Heroku maintenance modes."""
+
+    on = "ON"
+    off = "OFF"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        usage=(
+            "usage: maintenance.py [-h] [app_name] [ini_file] [on|off]"
+            "\nexample: python -m pyramid_heroku.maintenance on my_app etc/production.ini"
+        ),
+    )
+    parser.add_argument("mode", choices=[x.name for x in Mode], help="Maintenance mode")
+    parser.add_argument("app_name", help="Heroku app name")
+    parser.add_argument(
+        "ini_file",
+        nargs="?",
+        default="etc/production.ini",
+        help="Path to Pyramid configuration file ",
+    )
+
+    options = parser.parse_args()
+
+    h = Heroku(options.app_name, options.ini_file)
+
+    if Mode[options.mode] == Mode.on:
+        h.set_maintenance(True)
+    else:
+        h.set_maintenance(False)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyramid_heroku/migrate.py
+++ b/pyramid_heroku/migrate.py
@@ -1,161 +1,52 @@
 """Graceful DB migrations."""
 
-from requests import Response
-from requests import Session
+
+from pyramid_heroku import shell
+from pyramid_heroku.heroku import Heroku
 from time import sleep
-from typing import Optional
 
 import argparse
-import os
-import shlex
-import subprocess
-import sys
 
 
-class Heroku(object):
+def needs_migrate(heroku: Heroku) -> bool:
+    """
+    Checks current status of alembic branches.
 
-    api_endpoint = "https://api.heroku.com"
-
-    def __init__(self, app_name: str, ini_file: str) -> None:
-        """
-        :param app_name: Name of Heroku app or id.
-        :param ini_file: development.ini or production.ini filename.
-        """
-        self._formation = None
-        self.app_name = app_name
-        self.ini_file = ini_file
-
-        headers = {
-            "Authorization": f"Bearer {self.auth_key}",
-            "Accept": "application/vnd.heroku+json; version=3",
-            "Content-Type": "application/json",
-        }
-        self.session = Session()
-        self.session.headers.update(headers)
-
-    @property
-    def auth_key(self) -> Optional[str]:
-        """Heroku API secret.
-
-        https://devcenter.heroku.com/articles/platform-api-quickstart#authentication.
-        """
-        return os.environ.get("MIGRATE_API_SECRET_HEROKU")
-
-    def scale_down(self):
-        """Scale all app workers to 0."""
-        updates = [dict(type=t, quantity=0) for t in self.formation.keys()]
-        res = self.session.patch(
-            f"{self.api_endpoint}/apps/{self.app_name}/formation",
-            json=dict(updates=updates),
-        )
-        self.parse_response(res)
-        print("Scaled down to:")
-        for x in res.json():
-            print(f'{x["type"]}={x["quantity"]}')
-
-    def scale_up(self):
-        """Scale app back to initial state."""
-        updates = [dict(type=t, quantity=s) for t, s in self.formation.items()]
-        res = self.session.patch(
-            f"{self.api_endpoint}/apps/{self.app_name}/formation",
-            json=dict(updates=updates),
-        )
-        self.parse_response(res)
-        print("Scaled up to:")
-        for x in res.json():
-            print(f'{x["type"]}={x["quantity"]}')
-
-    @property
-    def formation(self):
-        """Get current app status and configuration.
-
-        :return: Heroku app status as dict.
-        """
-        if not self._formation:
-            res = self.session.get(
-                f"{self.api_endpoint}/apps/{self.app_name}/formation"
-            )
-            self.parse_response(res)
-            self._formation = {x["type"]: x["quantity"] for x in res.json()}
-        return self._formation
-
-    def shell(self, cmd: str) -> str:
-        """
-        Run shell command.
-
-        :param cmd: shell command to run
-        :return: stdout of command
-        """
-
-        p = subprocess.run(
-            shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        print(p.stdout.decode())
-        print(p.stderr.decode(), file=sys.stderr)
-        p.check_returncode()
-        return p.stdout.decode()
-
-    def needs_migrate(self):
-        """
-        Checks current status of alembic branches.
-
-        :return: True if current alembic branch is not up to date.
-        """
-        cmd = self.shell(f"alembic -c etc/alembic.ini -x ini={self.ini_file} current")
-        return "head" not in cmd
-
-    def alembic(self):
-        """
-        Run alembic migrations.
-        """
-        self.shell(f"alembic -c etc/alembic.ini -x ini={self.ini_file} upgrade head")
-
-    def get_maintenance(self) -> bool:
-        res = self.session.get(f"{self.api_endpoint}/apps/{self.app_name}")
-        self.parse_response(res)
-        return res.json()["maintenance"]
-
-    def set_maintenance(self, state: bool) -> None:
-        res = self.session.patch(
-            f"{self.api_endpoint}/apps/{self.app_name}", json=dict(maintenance=state)
-        )
-        if self.parse_response(res):
-            print("Maintenance {}".format("enabled" if state else "disabled"))
-
-    def parse_response(self, res: Response) -> Optional[bool]:
-        """
-        Parses Heroku API response.
-
-        :param res: requests object
-        :return: true if request succeeded
-        """
-        if res.status_code != 200:
-            print(res.json())
-        res.raise_for_status()
-        return True
-
-    def migrate(self):
-        """Run database migration if needed."""
-        print(self.app_name)
-        print(self.ini_file)
-
-        if self.needs_migrate():
-            was_in_maintenance = self.get_maintenance()
-            if not was_in_maintenance:
-                self.set_maintenance(True)
-            self.scale_down()
-            sleep(30)
-            self.alembic()
-            self.scale_up()
-            sleep(30)
-            if not was_in_maintenance:
-                # Don't disable maintenance mode if it was enabled externally.
-                self.set_maintenance(False)
-        else:
-            print("Database migration is not needed")
+    :return: True if current alembic branch is not up to date.
+    """
+    cmd = shell(f"alembic -c etc/alembic.ini -x ini={heroku.ini_file} current")
+    return "head" not in cmd
 
 
-def main():
+def alembic(heroku: Heroku) -> None:
+    """
+    Run alembic migrations.
+    """
+    shell(f"alembic -c etc/alembic.ini -x ini={heroku.ini_file} upgrade head")
+
+
+def migrate(heroku: Heroku) -> None:
+    """Run database migration if needed."""
+    print(heroku.app_name)
+    print(heroku.ini_file)
+
+    if needs_migrate(heroku):
+        was_in_maintenance = heroku.get_maintenance()
+        if not was_in_maintenance:
+            heroku.set_maintenance(True)
+        heroku.scale_down()
+        sleep(30)
+        alembic(heroku)
+        heroku.scale_up()
+        sleep(30)
+        if not was_in_maintenance:
+            # Don't disable maintenance mode if it was enabled externally.
+            heroku.set_maintenance(False)
+    else:
+        print("Database migration is not needed")
+
+
+def main() -> None:
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         usage=(
@@ -173,7 +64,7 @@ def main():
 
     options = parser.parse_args()
 
-    Heroku(options.app_name, options.ini_file).migrate()
+    migrate(Heroku(options.app_name, options.ini_file))
 
 
 if __name__ == "__main__":

--- a/pyramid_heroku/tests/test_heroku.py
+++ b/pyramid_heroku/tests/test_heroku.py
@@ -1,0 +1,106 @@
+"""Tests for Heroku API client."""
+
+from mock import call
+
+import json
+import mock
+import responses
+import unittest
+
+
+class TestHeroku(unittest.TestCase):
+    def setUp(self):
+        from pyramid_heroku.heroku import Heroku
+
+        self.Heroku = Heroku
+
+    @mock.patch("pyramid_heroku.heroku.print")
+    @responses.activate
+    def test_default_formation(self, out):
+        h = self.Heroku("test", "etc/production.ini")
+        h._formation = {"type": "web", "quantity": 8999}
+        responses.add(
+            responses.PATCH,
+            "https://api.heroku.com/apps/test/formation",  # noqa
+            status=200,
+            json=[{"type": "web", "quantity": 9001}],
+        )
+        h.scale_up()
+        out.assert_has_calls([call("Scaled up to:"), call("web=9001")])
+
+    @mock.patch("pyramid_heroku.heroku.print")
+    @responses.activate
+    def test_scale_down(self, out):
+        h = self.Heroku("test", "etc/production.ini")
+        responses.add(
+            responses.GET,
+            "https://api.heroku.com/apps/test/formation",  # noqa
+            status=200,
+            json=[{"type": "web", "quantity": 1}],
+        )
+        responses.add(
+            responses.PATCH,
+            "https://api.heroku.com/apps/test/formation",  # noqa
+            status=200,
+            json=[{"type": "web", "quantity": 0}],
+        )
+        h.scale_down()
+        out.assert_has_calls([call("Scaled down to:"), call("web=0")])
+
+    @mock.patch("pyramid_heroku.heroku.print")
+    @responses.activate
+    def test_scale_up(self, out):
+        h = self.Heroku("test", "etc/production.ini")
+        responses.add(
+            responses.GET,
+            "https://api.heroku.com/apps/test/formation",  # noqa
+            status=200,
+            json=[{"type": "web", "quantity": 1}],
+        )
+        responses.add(
+            responses.PATCH,
+            "https://api.heroku.com/apps/test/formation",  # noqa
+            status=200,
+            json=[{"type": "web", "quantity": 5}],
+        )
+        h.scale_up()
+        out.assert_has_calls([call("Scaled up to:"), call("web=5")])
+
+    @responses.activate
+    def test_get_maintenance(self):
+        h = self.Heroku("test", "etc/production.ini")
+        responses.add(  # noqa
+            responses.GET,
+            "https://api.heroku.com/apps/test",
+            status=200,
+            body=json.dumps({"maintenance": True}),
+        )
+        assert h.get_maintenance()
+
+    @mock.patch("pyramid_heroku.heroku.print")
+    @responses.activate
+    def test_maintenance_on(self, out):
+        h = self.Heroku("test", "etc/production.ini")
+        responses.add(
+            responses.PATCH, "https://api.heroku.com/apps/test", status=200  # noqa
+        )
+        h.set_maintenance(True)
+        out.assert_has_calls([call("Maintenance enabled")])
+
+    @mock.patch("pyramid_heroku.heroku.print")
+    @responses.activate
+    def test_maintenance_off(self, out):
+        h = self.Heroku("test", "etc/production.ini")
+        responses.add(
+            responses.PATCH, "https://api.heroku.com/apps/test", status=200  # noqa
+        )
+        h.set_maintenance(False)
+        out.assert_has_calls([call("Maintenance disabled")])
+
+    @mock.patch("pyramid_heroku.heroku.print")
+    @mock.patch("pyramid_heroku.heroku.Heroku.parse_response", return_value=False)
+    def test_set_maintanence_fail(self, pr, out):
+        """Test that set_maintenance() doesn't print the maintenance state if the call to it failed."""
+        h = self.Heroku("test", "etc/production.ini")
+        h.set_maintenance(True)
+        out.assert_not_called()

--- a/pyramid_heroku/tests/test_maintenance.py
+++ b/pyramid_heroku/tests/test_maintenance.py
@@ -1,0 +1,72 @@
+"""Tests for Heroku maintenance script."""
+
+
+from pyramid_heroku.maintenance import main
+
+import mock
+import pytest
+import responses
+import unittest
+
+
+class TestHerokuMaintenance(unittest.TestCase):
+    def setUp(self):
+        from pyramid_heroku.heroku import Heroku
+
+        self.Heroku = Heroku
+
+    def test_default_values(self):
+        from pyramid_heroku.maintenance import main
+
+        def assert_args(args, called_with):
+            with mock.patch("sys.argv", ["migrate.py"] + args), mock.patch(
+                "pyramid_heroku.maintenance.Heroku"
+            ) as heroku:
+                main()
+            heroku.assert_called_with(*called_with)
+
+        # all default
+        assert_args(["on", "my_test_app"], ["my_test_app", "etc/production.ini"])
+
+        # all custom
+        assert_args(
+            ["on", "my_test_app", "etc/develop2.ini"],
+            ["my_test_app", "etc/develop2.ini"],
+        )
+
+    @mock.patch("pyramid_heroku.maintenance.Heroku")
+    @mock.patch("pyramid_heroku.heroku.Session")
+    @responses.activate
+    def test_migrate_on(self, sess, Heroku):
+
+        with mock.patch("sys.argv", ["maintenance.py", "on", "my_app"]):
+            main()
+
+        Heroku().set_maintenance.assert_called_once_with(True)
+
+    @mock.patch("pyramid_heroku.maintenance.Heroku")
+    @mock.patch("pyramid_heroku.heroku.Session")
+    @responses.activate
+    def test_migrate_off(self, sess, Heroku):
+
+        with mock.patch("sys.argv", ["maintenance.py", "off", "my_app"]):
+            main()
+
+        Heroku().set_maintenance.assert_called_once_with(False)
+
+    @mock.patch("pyramid_heroku.subprocess")
+    @mock.patch("pyramid_heroku.print")
+    @mock.patch("pyramid_heroku.heroku.Session")
+    @responses.activate
+    def test_maintenance_non_zero(self, ses, out, sub):
+        h = self.Heroku("test", "etc/production.ini")
+        p = mock.Mock()
+        p.stdout = b"foo"
+        p.stderr = b"bar"
+        p.check_returncode.side_effect = Exception
+        sub.run.return_value = p
+
+        with pytest.raises(Exception):
+            main(h)
+
+        assert not out.called


### PR DESCRIPTION
### Do not touch maintenance mode if already set

When we want to enable/disable maintenance mode manually or externally,
we wouldn't want pyramid_heroku to reset it.

### Add option to manually set maintenance mode

Use `python -m pyramid_heroku.maintenance` to manually set Heroku
maintenance mode.

Also, some cleanup and refactor.